### PR TITLE
feat: add fontSize for `prose.code.block`

### DIFF
--- a/components/global/ProseCode.vue
+++ b/components/global/ProseCode.vue
@@ -42,6 +42,7 @@ css({
     position: "relative",
     overflow: "hidden",
     width: "100%",
+    fontSize: '{prose.code.block.fontSize}',
     margin: '{prose.code.block.margin}',
     borderRadius: '{radii.md}',
     border: '{prose.code.block.border}',

--- a/tokens.config.ts
+++ b/tokens.config.ts
@@ -283,6 +283,7 @@ export default defineTheme({
     },
     code: {
       block: {
+        fontSize: '{typography.fontSizes.sm}',
         margin: '{typography.verticalMargin.base} 0',
         border: '1px solid {colors.gray.200}',
         color: {


### PR DESCRIPTION
Missing compared to `prose.code.inline`, also bringing inconsistency visually.