### PR TITLE
feat: default background color

### DIFF
--- a/main.css
+++ b/main.css
@@ -2,10 +2,12 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: $dt('color.black');
+  background-color: $dt('color.white');
 }
 
 html.dark {
   color: $dt('color.white');
+  background-color: $dt('color.black');
 }
 
 .sr-only {


### PR DESCRIPTION
Add background-color for dark and light mode, otherwise we have a white text on a white background on dark mode by default.